### PR TITLE
Add Python API test scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# python
+__pycache__/
+*.py[cod]
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Testing
+
+To run the Python tests for the API service:
+
+```bash
+pytest
+```

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/health')
+def health():
+  return {'status': 'ok'}

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+def test_health():
+  response = client.get('/health')
+  assert response.status_code == 200
+  assert response.json() == {'status': 'ok'}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = ["api/tests"]
+addopts = -ra


### PR DESCRIPTION
## Summary
- set up FastAPI app with a `/health` route
- add pytest configuration and sample test
- ignore Python cache files
- document how to run pytest

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*