### PR TITLE
fix: add root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- add a root layout so Next.js can render `app/page.tsx`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_683dcad1d5e483328e7653c9855bf258