### PR TITLE
Add home page sections

### DIFF
--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import Home from '../app/page'
+
+test('home page renders heading and sections', () => {
+  const html = renderToStaticMarkup(<Home />)
+  expect(html).toContain('Welcome to IOYAO Next Bot')
+  expect(html).toContain('A Next.js application with FastAPI backend integration')
+  expect(html).toContain('Frontend')
+  expect(html).toContain('Backend')
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,20 @@
 export default function Home() {
-  return <h1>Hello Next.js!</h1>
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm">
+        <h1 className="text-4xl font-bold text-center mb-8">Welcome to IOYAO Next Bot</h1>
+        <p className="text-center text-lg mb-8">A Next.js application with FastAPI backend integration</p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
+          <div className="p-6 border border-gray-300 rounded-lg">
+            <h2 className="text-xl font-semibold mb-2">Frontend</h2>
+            <p className="text-gray-600">Built with Next.js 15 and React 19</p>
+          </div>
+          <div className="p-6 border border-gray-300 rounded-lg">
+            <h2 className="text-xl font-semibold mb-2">Backend</h2>
+            <p className="text-gray-600">Powered by FastAPI</p>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- expand homepage markup with headings and section descriptions
- add test for homepage markup

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844b4f954388332add3d58d3676d3b5