### PR TITLE
Remove pages entry from Tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,6 @@ import type { Config } from 'tailwindcss'
 
 export default {
   content: [
-    './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
@@ -16,4 +15,3 @@ export default {
   },
   plugins: [],
 } satisfies Config
-


### PR DESCRIPTION
## Summary
- drop unused `./pages/**/*` glob from Tailwind `content`

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844b4fb2fc483328368d435ce6b320b